### PR TITLE
Fix CSV newlines for proper rendering in Streamlit

### DIFF
--- a/mpcc_topics_2025-09-06_v2_with_youtube_links.csv
+++ b/mpcc_topics_2025-09-06_v2_with_youtube_links.csv
@@ -1,20 +1,161 @@
 Date,Length_Minutes,Councillors_Present,Citizens_Speaking,Topic_Count,Major_Topics,youtube-link
 2025-01-13,15,5,0,1,* Conference with legal counsel - anticipated litigation (three cases),https://youtu.be/1fGfbdbpmbo
-2025-01-14,387,5,7,8,* Accept December 10-2024 meeting minutes\n* Authorize City Manager to execute agreements for unleaded gasoline and renewable diesel\n* Transmittal of annual report on citywide impact fees collected as of June 30-2024\n* Downtown Development Parking Plazas 1-3 - RFQ discussion and direction\n* Receive and file report on labor relations and public input on upcoming labor negotiations with Menlo Park Police Sergeants’ Association\n* Approve 2025 City Council roll call voting procedure\n* Proclamation- National Law Enforcement Appreciation Day\n* Proclamation- Human Trafficking Prevention Month (January 2025),https://youtu.be/49XloN3MjVQ
-2025-01-28,273,5,10,11,* Conference with labor negotiators regarding Menlo Park Police Sergeants’ Association\n* Conference with legal counsel - anticipated litigation (one case)\n* Conference with legal counsel - existing litigation (Pistorino v. City of Menlo Park)\n* Accept City Council meeting minutes for December 17-2024 and January 13-2025\n* Request by Councilmember Schmidt for a future agenda topic - exploring feasibility of City-owned land as alternate sites for housing\n* Consider and adopt resolutions for Habitat for Humanity Greater San Francisco affordable housing project at 335 Pierce Rd\n* Approve 2025 City Council roll call voting procedure (amend salary schedule) effective Feb 9-2025\n* City Council agenda topics- February 2025\n* Communitywide electrification program- Home Upgrade Services progress report\n* Report on Black Liberation Month Celebration and recruitments for City advisory bodies\n* Report on teen college and career day and other meetings by council members,https://youtu.be/3JH179P0hWY?si=yJmn-DqAyC6wBpxC
-2025-02-11,187,5,5,10,* Authorize City Manager to execute primary grant agreement with San Mateo County Transportation Authority\n* Waive second reading and adopt ordinance to amend Chapter 12.18 for local amendments to 2022 California Building Standards Code\n* Adopt resolution supporting City’s application for San Mateo County Transportation Authority Shuttle Program\n* Consideration of needs analysis and potential strategies to enhance enrollment and financial sustainability at City-run preschool facilities\n* Receive and file the Annual Comprehensive Financial Report for fiscal year ended June 30-2024\n* City Council agenda topics- February – March 2025\n* Preliminary review of City-owned buildings leased to third parties\n* Accela Civic Platform update\n* Update on the City’s Five Year Street Maintenance Plan\n* Request by Mayor Combs for a future agenda topic - consideration of Santa Cruz Avenue closure,https://youtu.be/vhy1lKd_gsg
-2025-02-25,260,5,9,14,* Conference with legal counsel - anticipated litigation (one case)\n* Presentation- San Francisquito Creek Joint Powers Authority update\n* Consider applicants and make appointments to fill vacancies on Environmental Quality and Library Commissions\n* Accept City Council meeting minutes for January 14 and 28-2025\n* Adopt resolution authorizing agreement with San Francisquito Creek Joint Powers Authority for SAFER Bay project\n* Authorize City Manager to execute agreement with Schaaf & Wheeler Consulting Civil Engineers for SAFER Bay project\n* Introduce and waive first reading of ordinance amending Title 11 for parking restrictions for oversized vehicles\n* Consider and adopt resolution to amend fiscal year 2024-25 budget\n* City Council agenda topics- March 2025\n* Police department quarterly update - Q4 October – December 2024\n* Update on the City’s 2025-2029 Capital Improvement Plan\n* City Council fiscal year 2024-25 work plan update\n* Communitywide electrification program- Home Upgrade Services progress report\n* Homelessness services in Menlo Park,https://youtu.be/WKbZwowPP9Q
-2025-03-04,195,5,4,3,* Closed session conference with labor negotiator regarding Menlo Park Police Sergeants’ Association\n* Review and discuss site selection criteria and previous evaluation of City-owned properties for 2023-2031 Housing Element\n* City Council agenda topics- March 2025 - parking demand study timeline,https://youtu.be/8MgkdFTbEhE
-2025-03-11,424,5,19,6,* Closed session conference with labor negotiator regarding Menlo Park Police Sergeants’ Association\n* Conference with legal counsel - anticipated litigation (one case)\n* Appeal of Planning Commission’s approval of 320 Sheridan Dr\n* Approve Planning Commission Stipend Pilot Program\n* City Council agenda topics- March – April 2025\n* Report on Peninsula Clean Energy meeting- e-bike program- Meals-on-Wheels ride-along- and Rethink Waste Board meeting,https://youtu.be/GqR7qUs76jM
-2025-03-22,241,5,12,4,"* Annual City Council priority setting workshop including accomplishments, financial update, community survey results, public comment\n* Environmental Justice (EJ) Element implementation and community-identified priorities\n* Discussion on downtown vibrancy, economic development, transportation, electrification, bike routes, Urban Forest Management Plan, Downtown parking lots, street closures\n* Review and select top priorities for fiscal year 2025-26",https://youtu.be/8VcBYZGA268
-2025-03-25,228,5,7,15,* Conference with legal counsel - anticipated litigation (one potential case)\n* Accept City Council meeting minutes for February 11-2025\n* Initiate Menlo Park Landscaping Assessment District proceedings for fiscal year 2025-26\n* Award construction contract for 2025 Street Resurfacing project\n* Receive and file City Council and advisory body annual attendance report for March 2024 – February 2025\n* Receive and file investment portfolio reports for December 31-2024\n* Authorize City Manager to execute agreement with PG&E to replace high voltage circuits for West Menlo Series Circuit Street Light project\n* Provide direction on program enhancements and new project options for communitywide electrification program\n* City Council agenda topics- April 2025\n* Oversized vehicle administrative regulations\n* Homelessness services in Menlo Park\n* Report on upcoming March 22 Priorities setting meeting\n* Report on Councilmember Taylor’s appointment to San Francisco Bay Conservation and Development Commission\n* Report on C-CAG and BAWSCA meetings and upcoming March 4 City Council meeting\n* Report on considering natural grass instead of turf at Kelly Park,https://youtu.be/lw-KvHvM95c
-2025-04-15,239,4,11,12,* Closed session conference with labor negotiator regarding Menlo Park Police Sergeants’ Association\n* Accept City Council meeting minutes for February 25- March 4- 11 and 22- 2025\n* Consider and adopt two resolutions to accept funding from Metropolitan Transportation Commission Climate Program Implementation and Transit-Oriented Communities Planning Grants\n* Approve fiscal year 2025-26 budget principles\n* City Council agenda topics- April – May 2025\n* Annual City Council priority setting workshop final report\n* Proclamation for Arbor Day\n* Proclamation for Earth Day\n* Proclamation for Volunteer Recognition Day\n* Proclamation for Financial Literacy Month\n* Planning Commission applicant introductions\n* Discussion on potential downtown commission versus subcommittee and bike rack items from priority setting,https://youtu.be/xT9EyfX9ALw
-2025-04-29,339,5,20,12,* Conference with legal counsel - anticipated litigation (one potential case)\n* Proclamation- Recognizing Jon Johnston\n* Proclamation- Autism Acceptance Month\n* Consider applicants and make appointments to fill vacancies on various advisory bodies\n* Accept City Council meeting minutes for March 25-2025\n* Request for travel authorization for City Councilmember\n* Award a construction contract for the Middle Avenue Complete Streets project\n* Adopt resolution to authorize removal of parking from north side of Coleman Avenue and installation of a stop sign at Coleman Avenue and Santa Monica Avenue\n* Consider and adopt resolution to repeal the short-term closure of a portion of Ryans Lane\n* Adopt resolution extending reduction of Utility Users Tax to 0%\n* City Council agenda topics- May 2025\n* Communitywide electrification program- Home Upgrade Services progress report,https://youtu.be/aPXX4YEHDeE
-2025-05-13,233,5,4,13,* Conference with legal counsel - existing litigation (SAVE DOWNTOWN MENLO v. CITY OF MENLO PARK)\n* Proclamation- Public Works Week\n* Presentation- Youth Advisory Committee\n* Presentation- 2024 STEM Winners\n* Accept City Council meeting minutes for April 15-2025\n* Authorize City Manager to execute agreement for food services at Belle Haven Child Development Center\n* Adopt resolution renewing military equipment use ordinance and policy\n* Authorize City Manager to execute professional service agreement for Environmental Impact Report for 80 Willow Road development\n* Study session- Updated General Fund 5 year forecast for fiscal years 2024-2029\n* Study session- Provide direction on the five-year capital improvement plan including SAFER Bay project funding and Downtown Parking lots resurfacing\n* Study session- Aquatics Program review and potential modifications to operator agreement and fees\n* City Council agenda topics- May – June 2025\n* Police department quarterly update - Q1 January – March 2025,https://youtu.be/pevh8XwOU2w
-2025-05-27,386,5,16,13,* Conference with real property negotiators (1215 Chrysler Dr.)\n* Proclamation- Recognizing Run Club Menlo Park\n* Proclamation- Jewish American Heritage Month\n* Proclamation- Affordable Housing Month (May 2025)\n* Accept City Council meeting minutes for April 29-2025\n* Review investment portfolio reports for March 31-2025\n* Authorize City Manager to execute multi-year maintenance agreement for Bedwell Bayfront Park Landfill\n* Study session- Review and provide direction on Parkline Master Plan development project\n* Review and consider modifications to Habitat for Humanity Greater San Francisco Home Preservation program and authorize first amendment to community funding agreement\n* Consider and adopt resolution amending City Council Policy CC-01-1996 Community Funding Program and make appointments to a City Council subcommittee\n* Consider and adopt resolution to approve successor agreement between City of Menlo Park and Menlo Park Police Sergeants’ Association expiring October 31-2027\n* City Council agenda topics- June 2025\n* Update on implementation of the zero emission landscaping equipment ordinance,https://youtu.be/NbH4PCs-_qs
-2025-06-03,312,5,6,5,* Conference with legal counsel - existing litigation (SAVE DOWNTOWN MENLO v. CITY OF MENLO PARK)\n* Conference with legal counsel - anticipated litigation (one case)\n* Conference with legal counsel - anticipated litigation (one potential case)\n* Review and discuss responses to the Request for Qualifications (RFQ) for Development on Downtown Parking Plazas 1- 2 and-or 3 and provide direction on next steps\n* Direction to join in an action- City and County of San Francisco- et al.- v. Donald J- Trump- et al.,https://youtu.be/qKOZCXXUAXs
-2025-06-10,322,5,14,11,* Proclamation- Pride Month\n* Proclamation- Juneteenth\n* Proclamation- Gun Violence Awareness Day\n* Accept City Council meeting minutes for May 13-2025\n* Adopt resolution approving list of projects eligible for SB 1- The Road Repair and Accountability Act of 2017 funding\n* Authorize City Manager to execute agreement with Tripepi Smith for communications support services\n* Public hearing on proposed fiscal year 2025-26 budget and capital improvement plan\n* Consider and adopt resolution to repeal closure of Santa Cruz Avenue between Curtis and Doyle Streets to eastbound vehicular traffic\n* Request by Councilmember Taylor for a future agenda topic (Aquatics Program)\n* City Council agenda topics- June – July 2025\n* Reports on Peninsula Clean Energy tour and proposing future item on City Council positions on legislation,https://youtu.be/XN-HYOfqnYw
-2025-06-24,141,5,5,9,* Accept City Council meeting minutes for June 3-2025\n* Award construction contract for High Voltage Streetlight Conversion Project (removed- to return later)\n* Authorize City Manager to execute amendment for HVAC maintenance services\n* Authorize City Manager to execute amendment to water supply agreement\n* Consider and adopt resolution for Landscaping Assessment District for fiscal year 2025-26\n* Consider and adopt resolutions for fiscal year 2025-26- adopting budget and capital improvement plan\n* Consider and adopt resolution to amend fiscal year 2024-25 budget (reallocating General Fund balance to Strategic Pension Funding Reserve and General CIP Fund)\n* City Council agenda topics- July – August 2025\n* Communitywide electrification program- Home Upgrade Services progress report,https://youtu.be/0LYDWspVRlE
+2025-01-14,387,5,7,8,"* Accept December 10-2024 meeting minutes
+* Authorize City Manager to execute agreements for unleaded gasoline and renewable diesel
+* Transmittal of annual report on citywide impact fees collected as of June 30-2024
+* Downtown Development Parking Plazas 1-3 - RFQ discussion and direction
+* Receive and file report on labor relations and public input on upcoming labor negotiations with Menlo Park Police Sergeants’ Association
+* Approve 2025 City Council roll call voting procedure
+* Proclamation- National Law Enforcement Appreciation Day
+* Proclamation- Human Trafficking Prevention Month (January 2025)",https://youtu.be/49XloN3MjVQ
+2025-01-28,273,5,10,11,"* Conference with labor negotiators regarding Menlo Park Police Sergeants’ Association
+* Conference with legal counsel - anticipated litigation (one case)
+* Conference with legal counsel - existing litigation (Pistorino v. City of Menlo Park)
+* Accept City Council meeting minutes for December 17-2024 and January 13-2025
+* Request by Councilmember Schmidt for a future agenda topic - exploring feasibility of City-owned land as alternate sites for housing
+* Consider and adopt resolutions for Habitat for Humanity Greater San Francisco affordable housing project at 335 Pierce Rd
+* Approve 2025 City Council roll call voting procedure (amend salary schedule) effective Feb 9-2025
+* City Council agenda topics- February 2025
+* Communitywide electrification program- Home Upgrade Services progress report
+* Report on Black Liberation Month Celebration and recruitments for City advisory bodies
+* Report on teen college and career day and other meetings by council members",https://youtu.be/3JH179P0hWY?si=yJmn-DqAyC6wBpxC
+2025-02-11,187,5,5,10,"* Authorize City Manager to execute primary grant agreement with San Mateo County Transportation Authority
+* Waive second reading and adopt ordinance to amend Chapter 12.18 for local amendments to 2022 California Building Standards Code
+* Adopt resolution supporting City’s application for San Mateo County Transportation Authority Shuttle Program
+* Consideration of needs analysis and potential strategies to enhance enrollment and financial sustainability at City-run preschool facilities
+* Receive and file the Annual Comprehensive Financial Report for fiscal year ended June 30-2024
+* City Council agenda topics- February – March 2025
+* Preliminary review of City-owned buildings leased to third parties
+* Accela Civic Platform update
+* Update on the City’s Five Year Street Maintenance Plan
+* Request by Mayor Combs for a future agenda topic - consideration of Santa Cruz Avenue closure",https://youtu.be/vhy1lKd_gsg
+2025-02-25,260,5,9,14,"* Conference with legal counsel - anticipated litigation (one case)
+* Presentation- San Francisquito Creek Joint Powers Authority update
+* Consider applicants and make appointments to fill vacancies on Environmental Quality and Library Commissions
+* Accept City Council meeting minutes for January 14 and 28-2025
+* Adopt resolution authorizing agreement with San Francisquito Creek Joint Powers Authority for SAFER Bay project
+* Authorize City Manager to execute agreement with Schaaf & Wheeler Consulting Civil Engineers for SAFER Bay project
+* Introduce and waive first reading of ordinance amending Title 11 for parking restrictions for oversized vehicles
+* Consider and adopt resolution to amend fiscal year 2024-25 budget
+* City Council agenda topics- March 2025
+* Police department quarterly update - Q4 October – December 2024
+* Update on the City’s 2025-2029 Capital Improvement Plan
+* City Council fiscal year 2024-25 work plan update
+* Communitywide electrification program- Home Upgrade Services progress report
+* Homelessness services in Menlo Park",https://youtu.be/WKbZwowPP9Q
+2025-03-04,195,5,4,3,"* Closed session conference with labor negotiator regarding Menlo Park Police Sergeants’ Association
+* Review and discuss site selection criteria and previous evaluation of City-owned properties for 2023-2031 Housing Element
+* City Council agenda topics- March 2025 - parking demand study timeline",https://youtu.be/8MgkdFTbEhE
+2025-03-11,424,5,19,6,"* Closed session conference with labor negotiator regarding Menlo Park Police Sergeants’ Association
+* Conference with legal counsel - anticipated litigation (one case)
+* Appeal of Planning Commission’s approval of 320 Sheridan Dr
+* Approve Planning Commission Stipend Pilot Program
+* City Council agenda topics- March – April 2025
+* Report on Peninsula Clean Energy meeting- e-bike program- Meals-on-Wheels ride-along- and Rethink Waste Board meeting",https://youtu.be/GqR7qUs76jM
+2025-03-22,241,5,12,4,"* Annual City Council priority setting workshop including accomplishments, financial update, community survey results, public comment
+* Environmental Justice (EJ) Element implementation and community-identified priorities
+* Discussion on downtown vibrancy, economic development, transportation, electrification, bike routes, Urban Forest Management Plan, Downtown parking lots, street closures
+* Review and select top priorities for fiscal year 2025-26",https://youtu.be/8VcBYZGA268
+2025-03-25,228,5,7,15,"* Conference with legal counsel - anticipated litigation (one potential case)
+* Accept City Council meeting minutes for February 11-2025
+* Initiate Menlo Park Landscaping Assessment District proceedings for fiscal year 2025-26
+* Award construction contract for 2025 Street Resurfacing project
+* Receive and file City Council and advisory body annual attendance report for March 2024 – February 2025
+* Receive and file investment portfolio reports for December 31-2024
+* Authorize City Manager to execute agreement with PG&E to replace high voltage circuits for West Menlo Series Circuit Street Light project
+* Provide direction on program enhancements and new project options for communitywide electrification program
+* City Council agenda topics- April 2025
+* Oversized vehicle administrative regulations
+* Homelessness services in Menlo Park
+* Report on upcoming March 22 Priorities setting meeting
+* Report on Councilmember Taylor’s appointment to San Francisco Bay Conservation and Development Commission
+* Report on C-CAG and BAWSCA meetings and upcoming March 4 City Council meeting
+* Report on considering natural grass instead of turf at Kelly Park",https://youtu.be/lw-KvHvM95c
+2025-04-15,239,4,11,12,"* Closed session conference with labor negotiator regarding Menlo Park Police Sergeants’ Association
+* Accept City Council meeting minutes for February 25- March 4- 11 and 22- 2025
+* Consider and adopt two resolutions to accept funding from Metropolitan Transportation Commission Climate Program Implementation and Transit-Oriented Communities Planning Grants
+* Approve fiscal year 2025-26 budget principles
+* City Council agenda topics- April – May 2025
+* Annual City Council priority setting workshop final report
+* Proclamation for Arbor Day
+* Proclamation for Earth Day
+* Proclamation for Volunteer Recognition Day
+* Proclamation for Financial Literacy Month
+* Planning Commission applicant introductions
+* Discussion on potential downtown commission versus subcommittee and bike rack items from priority setting",https://youtu.be/xT9EyfX9ALw
+2025-04-29,339,5,20,12,"* Conference with legal counsel - anticipated litigation (one potential case)
+* Proclamation- Recognizing Jon Johnston
+* Proclamation- Autism Acceptance Month
+* Consider applicants and make appointments to fill vacancies on various advisory bodies
+* Accept City Council meeting minutes for March 25-2025
+* Request for travel authorization for City Councilmember
+* Award a construction contract for the Middle Avenue Complete Streets project
+* Adopt resolution to authorize removal of parking from north side of Coleman Avenue and installation of a stop sign at Coleman Avenue and Santa Monica Avenue
+* Consider and adopt resolution to repeal the short-term closure of a portion of Ryans Lane
+* Adopt resolution extending reduction of Utility Users Tax to 0%
+* City Council agenda topics- May 2025
+* Communitywide electrification program- Home Upgrade Services progress report",https://youtu.be/aPXX4YEHDeE
+2025-05-13,233,5,4,13,"* Conference with legal counsel - existing litigation (SAVE DOWNTOWN MENLO v. CITY OF MENLO PARK)
+* Proclamation- Public Works Week
+* Presentation- Youth Advisory Committee
+* Presentation- 2024 STEM Winners
+* Accept City Council meeting minutes for April 15-2025
+* Authorize City Manager to execute agreement for food services at Belle Haven Child Development Center
+* Adopt resolution renewing military equipment use ordinance and policy
+* Authorize City Manager to execute professional service agreement for Environmental Impact Report for 80 Willow Road development
+* Study session- Updated General Fund 5 year forecast for fiscal years 2024-2029
+* Study session- Provide direction on the five-year capital improvement plan including SAFER Bay project funding and Downtown Parking lots resurfacing
+* Study session- Aquatics Program review and potential modifications to operator agreement and fees
+* City Council agenda topics- May – June 2025
+* Police department quarterly update - Q1 January – March 2025",https://youtu.be/pevh8XwOU2w
+2025-05-27,386,5,16,13,"* Conference with real property negotiators (1215 Chrysler Dr.)
+* Proclamation- Recognizing Run Club Menlo Park
+* Proclamation- Jewish American Heritage Month
+* Proclamation- Affordable Housing Month (May 2025)
+* Accept City Council meeting minutes for April 29-2025
+* Review investment portfolio reports for March 31-2025
+* Authorize City Manager to execute multi-year maintenance agreement for Bedwell Bayfront Park Landfill
+* Study session- Review and provide direction on Parkline Master Plan development project
+* Review and consider modifications to Habitat for Humanity Greater San Francisco Home Preservation program and authorize first amendment to community funding agreement
+* Consider and adopt resolution amending City Council Policy CC-01-1996 Community Funding Program and make appointments to a City Council subcommittee
+* Consider and adopt resolution to approve successor agreement between City of Menlo Park and Menlo Park Police Sergeants’ Association expiring October 31-2027
+* City Council agenda topics- June 2025
+* Update on implementation of the zero emission landscaping equipment ordinance",https://youtu.be/NbH4PCs-_qs
+2025-06-03,312,5,6,5,"* Conference with legal counsel - existing litigation (SAVE DOWNTOWN MENLO v. CITY OF MENLO PARK)
+* Conference with legal counsel - anticipated litigation (one case)
+* Conference with legal counsel - anticipated litigation (one potential case)
+* Review and discuss responses to the Request for Qualifications (RFQ) for Development on Downtown Parking Plazas 1- 2 and-or 3 and provide direction on next steps
+* Direction to join in an action- City and County of San Francisco- et al.- v. Donald J- Trump- et al.",https://youtu.be/qKOZCXXUAXs
+2025-06-10,322,5,14,11,"* Proclamation- Pride Month
+* Proclamation- Juneteenth
+* Proclamation- Gun Violence Awareness Day
+* Accept City Council meeting minutes for May 13-2025
+* Adopt resolution approving list of projects eligible for SB 1- The Road Repair and Accountability Act of 2017 funding
+* Authorize City Manager to execute agreement with Tripepi Smith for communications support services
+* Public hearing on proposed fiscal year 2025-26 budget and capital improvement plan
+* Consider and adopt resolution to repeal closure of Santa Cruz Avenue between Curtis and Doyle Streets to eastbound vehicular traffic
+* Request by Councilmember Taylor for a future agenda topic (Aquatics Program)
+* City Council agenda topics- June – July 2025
+* Reports on Peninsula Clean Energy tour and proposing future item on City Council positions on legislation",https://youtu.be/XN-HYOfqnYw
+2025-06-24,141,5,5,9,"* Accept City Council meeting minutes for June 3-2025
+* Award construction contract for High Voltage Streetlight Conversion Project (removed- to return later)
+* Authorize City Manager to execute amendment for HVAC maintenance services
+* Authorize City Manager to execute amendment to water supply agreement
+* Consider and adopt resolution for Landscaping Assessment District for fiscal year 2025-26
+* Consider and adopt resolutions for fiscal year 2025-26- adopting budget and capital improvement plan
+* Consider and adopt resolution to amend fiscal year 2024-25 budget (reallocating General Fund balance to Strategic Pension Funding Reserve and General CIP Fund)
+* City Council agenda topics- July – August 2025
+* Communitywide electrification program- Home Upgrade Services progress report",https://youtu.be/0LYDWspVRlE
 2025-07-07,125,4,0,1,* Conference with legal counsel - anticipated litigation (one potential case),NA
-2025-07-08,320,4,15,11,* Proclamation- Park and Recreation Month\n* Presentation- West Bay Sanitary District recycled water update\n* Accept City Council meeting minutes for May 27 and June 10-2025\n* Award construction contract for High Voltage Streetlight Conversion project and approve appropriation from General Capital Improvement Fund\n* Authorize City Manager to execute first amendment to lease agreement for City property at 802 Middle Ave\n* Provide direction on design and improvements for public plaza in closed portion of Santa Cruz Avenue along the 600 block\n* Consider and adopt resolution to amend salary schedule effective July 27-2025 and resolutions to approve side letters of agreement with SEIU Local 521 and AFSCME Local 829\n* Provide direction on potential options for local amendments to the California Building Standards code to support electric readiness\n* City Council agenda topics- August 2025\n* City Council fiscal year 2025-26 work plan\n* City Council meeting transportation- location- interpretation and translation services,https://youtu.be/bPGhuwVu4xs
+2025-07-08,320,4,15,11,"* Proclamation- Park and Recreation Month
+* Presentation- West Bay Sanitary District recycled water update
+* Accept City Council meeting minutes for May 27 and June 10-2025
+* Award construction contract for High Voltage Streetlight Conversion project and approve appropriation from General Capital Improvement Fund
+* Authorize City Manager to execute first amendment to lease agreement for City property at 802 Middle Ave
+* Provide direction on design and improvements for public plaza in closed portion of Santa Cruz Avenue along the 600 block
+* Consider and adopt resolution to amend salary schedule effective July 27-2025 and resolutions to approve side letters of agreement with SEIU Local 521 and AFSCME Local 829
+* Provide direction on potential options for local amendments to the California Building Standards code to support electric readiness
+* City Council agenda topics- August 2025
+* City Council fiscal year 2025-26 work plan
+* City Council meeting transportation- location- interpretation and translation services",https://youtu.be/bPGhuwVu4xs
 2025-08-19,202,5,0,1,* Closed session conference with labor negotiator regarding Menlo Park Police Sergeants’ Association,https://youtu.be/fvg7WHljjLA


### PR DESCRIPTION
The bullet points in the "Major_Topics" column were not rendering with line breaks because the newlines were encoded as literal '\n' strings.

This change corrects the CSV file by:
- Replacing the '\n' strings with actual newline characters.
- Enclosing the multi-line fields in double quotes to ensure the CSV is parsed correctly.

This will allow Streamlit to render the bullet points with the intended line breaks.